### PR TITLE
Change to use a configured hostname with actual hostname as default

### DIFF
--- a/run-exhibitor.sh
+++ b/run-exhibitor.sh
@@ -1,6 +1,6 @@
 #!/usr/bin/env bash
 
-CMD="-jar /opt/exhibitor/exhibitor.jar --defaultconfig /opt/exhibitor/exhibitor.properties --hostname $(awk 'NR==1 {print $1}' /etc/hosts)"
+CMD="-jar /opt/exhibitor/exhibitor.jar --defaultconfig /opt/exhibitor/exhibitor.properties --hostname ${ZKHOSTNAME:-$HOSTNAME}"
 
 if [ "$CONFIGTYPE" = "file" ]; then
 


### PR DESCRIPTION
I'm not sure why it had this odd value to start with where all servers would always have an id of 127.0.0.1.
